### PR TITLE
Add cmake to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:jessie
 
 RUN apt-get update \
   && apt-get -y --quiet --force-yes upgrade \
-  && apt-get install -y --no-install-recommends ca-certificates gcc g++ make build-essential git autoconf automake  curl libtool libtool-bin libssl-dev libcurl4-openssl-dev \
+  && apt-get install -y --no-install-recommends ca-certificates gcc g++ make cmake build-essential git autoconf automake  curl libtool libtool-bin libssl-dev libcurl4-openssl-dev \
   && git clone --depth=50 --branch=master git://github.com/davehorton/drachtio-server.git /usr/local/src/drachtio-server \
   && cd /usr/local/src/drachtio-server \
   && git submodule update --init --recursive \


### PR DESCRIPTION
```
cd ../deps/prometheus-cpp && mkdir -p build && cd build  && \
cmake .. -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_INSTALL_PREFIX=`pwd` && \
make && make install
/bin/bash: line 1: cmake: command not found
Makefile:1368: recipe for target '../deps/prometheus-cpp/build/lib/libprometheus-cpp-core.a' failed
make: *** [../deps/prometheus-cpp/build/lib/libprometheus-cpp-core.a] Error 127
The command '/bin/sh -c apt-get update   && apt-get -y --quiet --force-yes upgrade   && apt-get install -y --no-install-recommends ca-certificates gcc g++ make build-essential git autoconf automake  curl libtool libtool-bin libssl-dev libcurl4-openssl-dev   && git clone --depth=50 --branch=master git://github.com/davehorton/drachtio-server.git /usr/local/src/drachtio-server   && cd /usr/local/src/drachtio-server   && git submodule update --init --recursive   && ./bootstrap.sh   && mkdir /usr/local/src/drachtio-server/build    && cd /usr/local/src/drachtio-server/build    && ../configure CPPFLAGS='-DNDEBUG' CXXFLAGS='-O0'   && make   && make install   && apt-get purge -y --quiet --force-yes --auto-remove gcc g++ make build-essential git autoconf automake curl libtool libtool-bin   && rm -rf /var/lib/{apt,dpkg,cache,log}/   && rm -Rf /var/log/*   && rm -Rf /var/lib/apt/lists/*   && cd /usr/local/src   && rm -Rf drachtio-server   && cd /usr/local/bin   && rm -f timer ssltest parser uri_test test_https test_asio_curl' returned a non-zero code: 2

```